### PR TITLE
Set FQDN before registering to labsat

### DIFF
--- a/ansible/configs/satellite-vm/pre_software.yml
+++ b/ansible/configs/satellite-vm/pre_software.yml
@@ -14,11 +14,12 @@
   hosts:
     - all:!windows:!satellite_hosts:!satellites
   become: true
-  gather_facts: False
+  gather_facts: true
   tags:
     - step004
     - common_tasks
   roles:
+    - role: satellite-public-hostname
     - role: "set-repositories"
       vars:
         rhel_repos: "{{ rhel7_repos }}"
@@ -31,11 +32,12 @@
   hosts:
     - satellites
   become: true
-  gather_facts: False
+  gather_facts: true
   tags:
     - step004
     - satellite_tasks
   roles:
+    - role: satellite-public-hostname
     - role: "set-repositories"
       vars:
         rhel_repos: "{{ rhel7_repos + satellite_repos }}"

--- a/ansible/configs/satellite-vm/software.yml
+++ b/ansible/configs/satellite-vm/software.yml
@@ -13,10 +13,6 @@
   become: True
   gather_facts: True
   tasks:
-
-    - import_role:
-        name: satellite-public-hostname
-
     - when: install_satellite
       include_role:
         name: "{{ _role }}"

--- a/ansible/roles/satellite-public-hostname/tasks/main.yml
+++ b/ansible/roles/satellite-public-hostname/tasks/main.yml
@@ -24,10 +24,19 @@
     - public_hostname
 
 - name: Add public hostname name in hosts file
-  lineinfile: 
-    dest: /etc/hosts 
-    state: present 
-    insertafter: EOF 
+  lineinfile:
+    dest: /etc/hosts
+    state: present
+    insertafter: EOF
     line: "{{ ansible_default_ipv4['address'] }}  {{ publicname }}"
   tags:
     - public_hostname
+
+- name: Add IP address of all hosts to all hosts
+  lineinfile:
+    dest: /etc/hosts
+    regexp: '.*{{ hostvars[item].ansible_fqdn  }}$'
+    line: "{{ hostvars[item].ansible_default_ipv4['address'] }} {{ hostvars[item].ansible_fqdn }}"
+    state: present
+  with_items: "{{ groups.all }}"
+


### PR DESCRIPTION
The satellite-public-name needs to be set before registering to the lab sat. This PR fixes that